### PR TITLE
Fix for pre-encoded URLs. Issue is that when we call

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "foursquare-fhttp"
 
-version := "0.1.13"
+version := "0.1.14"
 
 organization := "com.foursquare"
 

--- a/src/main/scala/com/foursquare/fhttp/FHttpRequest.scala
+++ b/src/main/scala/com/foursquare/fhttp/FHttpRequest.scala
@@ -469,9 +469,12 @@ case class FHttpRequest ( client: FHttpClient,
 
   protected def process[T] (method: HttpMethod, processor: Future[HttpResponse] => T): T = {
     val uriObj = new java.net.URI(uri)
-    val req = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                                     method,
-                                     uri.substring(uri.indexOf(uriObj.getPath)))
+    val req =
+      new DefaultHttpRequest(
+        HttpVersion.HTTP_1_1,
+        method,
+        uri.substring(uri.indexOf(uriObj.getRawPath))
+      )
     options.reverse.foreach(_(req))
     processor(service(req))
   }

--- a/src/test/scala/com/foursquare/fhttp/FHttpTest.scala
+++ b/src/test/scala/com/foursquare/fhttp/FHttpTest.scala
@@ -358,4 +358,18 @@ class FHttpClientTest {
       .timeout(5000).get_!()
     assertEquals(res, "")
   }
+
+  @Test
+  def testEncodedURLQuery {
+    val expected1 = "/ラーメン"
+    val req1 = client("/ラーメン")
+    val res1 = req1.get_!()
+    assertEquals(res1, "")
+
+    val expected2 = "/%E3%83%A9%E3%83%BC%E3%83%A1%E3%83%B3"
+    val req2 = client("/%E3%83%A9%E3%83%BC%E3%83%A1%E3%83%B3")
+    val res2 = req2.get_!()
+    assertEquals(res2, "")
+  }
+
 }


### PR DESCRIPTION
`java.net.URI.getPath`, we are getting back a decoded string and doing a
substring match on `uri` which is a plain string. This means if `uri` is
encoded, then our substring match will fail and throw an exception. I've
added a test case to illustrate this break.

The `expected2` case in the new test is the case that fails on the current version.