### PR TITLE
Honor `networkaddress.cache.ttl` to allow DNS refreshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You will probably want to override FHttpClient.service to add your own logging a
 ## Adding FHttp to your build ##
 The project is cross-compiled for scala 2.9.2 and scala 2.10.3. In your build.sbt, add:
 
-    "com.foursquare" %% "foursquare-fhttp" % "0.1.14"
+    "com.foursquare" %% "foursquare-fhttp" % "0.1.15"
 
 
 ## Some Simple Examples ##
@@ -114,4 +114,7 @@ Here's a slightly more complicated oauth (and HTTPS) example, using a [Dropbox A
 
     // and go do some stuff with it.
     api("/1/account/info").oauth(consumer, accessToken).get_!()
+
+## Network Address Cache TTL ##
+FHttpClient honors the Java Security setting `networkaddress.cache.ttl`.  A positive value for this setting indicates the number of seconds after which DNS cache entries are expired, triggering re-resolution.  This support was introduced in Finagle 6.20.0 and FHttp 0.1.15.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "foursquare-fhttp"
 
-version := "0.1.14"
+version := "0.1.15"
 
 organization := "com.foursquare"
 

--- a/src/main/scala/com/foursquare/fhttp/FHttpClient.scala
+++ b/src/main/scala/com/foursquare/fhttp/FHttpClient.scala
@@ -3,7 +3,7 @@
 package com.foursquare.fhttp
 
 import com.twitter.conversions.time._
-import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.finagle.{InetResolver, Name, Service, SimpleFilter}
 import com.twitter.finagle.builder.ClientBuilder
 import com.twitter.finagle.builder.ClientConfig.Yes
 import com.twitter.finagle.http.Http
@@ -36,7 +36,8 @@ class FHttpClient ( val name: String,
 
   val firstHostPort = hostPort.split(",",2)(0)
 
-  def builtClient = builder.name(name).hosts(hostPort).build()
+  // Use dest() instead of hosts() to allow DNS cache expiry
+  def builtClient = builder.name(name).dest(Name.Bound(InetResolver.bind(hostPort), hostPort)).build()
 
   val baseService = throwHttpErrorsFilter andThen builtClient
 


### PR DESCRIPTION
Currently, FHttp uses a permanent cache of DNS lookups, which causes problems when applications are pointed at DNS entries whose values are subject to change (for example, AWS Elastic Load Balancers).

This issue has affected Finagle generally, as discussed [here](https://groups.google.com/forum/#!topic/finaglers/HqfNWJF3qZk).  A [fix went into Finagle](https://github.com/twitter/finagle/commit/1c06105a446994f314773de3713c8d98ebcab482) last year.  However, the `hosts()` method of `ClientBuilder`, which is used by FHttp, does not take advantage of the fix.

With the change in this Pull Request, FHttp will use a Finagle resolver that refreshes DNS entries on a timer if the Java Security property `networkaddress.cache.ttl` is set to a positive value.  If that property is negative or unset, FHttp will behave as it currently does.
